### PR TITLE
Remove join in applicants quick search index in order to allow to retrieve applicants without companies

### DIFF
--- a/source/CommonJobs/CommonJobs.Infrastructure/Indexes/Applicant_QuickSearch.cs
+++ b/source/CommonJobs/CommonJobs.Infrastructure/Indexes/Applicant_QuickSearch.cs
@@ -28,7 +28,7 @@ namespace CommonJobs.Infrastructure.Indexes
                                     {
                                         applicant.FirstName,
                                         applicant.LastName,
-                                        string.Join(" ", applicant.CompanyHistory.Select(x => x.CompanyName)),
+                                        applicant.CompanyHistory.Select(x => x.CompanyName),
                                         applicant.Skills
                                     },
                                     Highlighted = applicant.IsHighlighted,


### PR DESCRIPTION
Fallaba cuando CompanyHistory era null, ahora ya no. El filtro parece seguir funcionando bien.
