### PR TITLE
Updated vacation total days logic to count all days.

### DIFF
--- a/source/CommonJobs/CommonJobs.Domain/Vacation.cs
+++ b/source/CommonJobs/CommonJobs.Domain/Vacation.cs
@@ -15,15 +15,7 @@ namespace CommonJobs.Domain
         {
             get
             {
-                var totalDays = 0;
-                for (var date = From; date < To; date = date.AddDays(1))
-                {
-                    if (date.DayOfWeek != DayOfWeek.Saturday
-                        && date.DayOfWeek != DayOfWeek.Sunday)
-                        totalDays++;
-                }
-
-                return totalDays;
+                return (int)(To - From).TotalDays;
             }
         }
     }


### PR DESCRIPTION
As per conversation with Gabriel, the vacation days should be all counted,
including holidays and weekends. Thus, removed the validation wether a day is
Saturday or Sunday and simplified it.
