### PR TITLE
Remove use of Raven/DocumentsByEntityName in migrations and add a helper...

### DIFF
--- a/source/CommonJobs/CommonJobs.Migrations/201205011017_CleanVacationsStringData.cs
+++ b/source/CommonJobs/CommonJobs.Migrations/201205011017_CleanVacationsStringData.cs
@@ -13,34 +13,12 @@ namespace CommonJobs.Migrations
     [Migration("201205011017", "Clean vacations string data")]
     public class CleanVacationsStringData : Migration
     {
-        const int PageSize = 64;
         const string UpBackupKey = "MigrationBackup_Up_201205011017_CleanVacationsStringData";
         const string DownBackupKey = "MigrationBackup_Down_201205011017_CleanVacationsStringData";
 
         private void ForAllEmployees(Action<RavenJObject> action)
         {
-            int start = 0;
-            while (true)
-            {
-                var results = DocumentStore.DatabaseCommands.Query(
-                    "Raven/DocumentsByEntityName",
-                    new IndexQuery()
-                    {
-                        Query = "Tag:Employees",
-                        PageSize = PageSize,
-                        Start = start
-                    },
-                    null);
-
-
-                if (results.Results.Count == 0)
-                    break;
-
-                foreach (var result in results.Results)
-                    action(result);
-
-                start += PageSize;
-            }
+            DoInResults(action, index: "Dynamic/Employees");
         }
 
         public override void Up()

--- a/source/CommonJobs/CommonJobs.Raven.Migrations/CommonJobs.Raven.Migrations.csproj
+++ b/source/CommonJobs/CommonJobs.Raven.Migrations/CommonJobs.Raven.Migrations.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Raven.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\Libs\RavenDB\Client\Raven.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Raven.Client.Debug, Version=1.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\Libs\RavenDB\Client\Raven.Client.Debug.dll</HintPath>
     </Reference>

--- a/source/CommonJobs/CommonJobs.Raven.Migrations/Migration.cs
+++ b/source/CommonJobs/CommonJobs.Raven.Migrations/Migration.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Raven.Client;
+using Raven.Abstractions.Data;
+using Raven.Json.Linq;
 
 namespace CommonJobs.Raven.Migrations
 {
@@ -12,5 +14,48 @@ namespace CommonJobs.Raven.Migrations
 
         public abstract void Up();
         public abstract void Down();
+
+        protected bool IndexExists(string index, int pageSize = 64)
+        {
+            int start = 0;
+            while (true)
+            {
+                var names = DocumentStore.DatabaseCommands.GetIndexNames(start, pageSize);
+                if (names.Length == 0)
+                    return false;
+                else if (names.Contains(index))
+                    return true;
+                start += pageSize;
+            }
+        }
+
+        protected void DoInResults(
+            Action<RavenJObject> action, 
+            string query = "*:*", 
+            int pageSize = 64, 
+            string index = "Dynamic", 
+            string[] includes = null)
+        {
+            int start = 0;
+            while (true)
+            {
+                var qry = new IndexQuery() 
+                { 
+                    Query = query, 
+                    PageSize = pageSize,
+                    Start = start //TODO: consider to use another thing in place of start
+                };
+
+                var results = DocumentStore.DatabaseCommands.Query(index, qry, includes);
+
+                if (results.Results.Count == 0)
+                    break;
+
+                foreach (var result in results.Results)
+                    action(result);
+
+                start += pageSize;
+            }
+        }
     }
 }


### PR DESCRIPTION
... method to simplify migrations writing
