### PR TITLE
Guarantee security in migration access

### DIFF
--- a/source/CommonJobs/CommonJobs.Mvc.UI/Controllers/MigrationsController.cs
+++ b/source/CommonJobs/CommonJobs.Mvc.UI/Controllers/MigrationsController.cs
@@ -31,6 +31,7 @@ namespace CommonJobs.Mvc.UI.Controllers
 
         [AcceptVerbs(HttpVerbs.Post)]
         [ActionName("Index")]
+        [ValidateAntiForgeryToken(Salt = "To avoid IP spoofing")] //http://stackoverflow.com/questions/8170830/can-request-userhostaddress-tostring-be-spoofed-asp-net-4-0-iis-7-5
         public ActionResult Post(IEnumerable<MigrationAction> actions)
         {
             var migrator = new Migrator(RavenSessionManager.DocumentStore, typeof(MigrationClass).Assembly);

--- a/source/CommonJobs/CommonJobs.Mvc.UI/Views/Migrations/Index.cshtml
+++ b/source/CommonJobs/CommonJobs.Mvc.UI/Views/Migrations/Index.cshtml
@@ -19,6 +19,7 @@
 <h1>Migrations</h1>
 @using (Html.BeginForm())
 {
+  @Html.AntiForgeryToken("To avoid IP spoofing")
   <table>
     <thead>
       <tr>

--- a/source/CommonJobs/CommonJobs.Mvc.UI/Web.config
+++ b/source/CommonJobs/CommonJobs.Mvc.UI/Web.config
@@ -14,15 +14,14 @@
     <add key="webpages:Version" value="1.0.0.0" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="AllowedMigrationSingleIPs" value="localhost, 127.0.0.1, 192.168.4.178, 190.194.112.55" />
+    <add key="AllowedMigrationSingleIPs" value="127.0.0.1, 192.168.4.178, 190.194.112.55" />
     <!--
-    localhost: La propia máquina entrando a http://localhost:8888
-    127.0.0.1: Al parecer localhost no funciona en algún caso.
+    127.0.0.1: La propia máquina entrando a http://127.0.0.1:8888 (dependiendo de la configuración del equipo localhost podría no funcionar por estar mapeado a IP v. 6)
     192.168.4.178: Máquina de la oficina de Andrés entrando a http://192.168.0.20:8888
     190.194.112.55: Máquina de Andrés entrando a http://commonjobs.makingsense.com:8888
     -->
     <!-- Otros ejemplos
-   <add key="AllowedMigrationSingleIPs" value="localhost,10.2.80.21,192.168.2.2"/>
+   <add key="AllowedMigrationSingleIPs" value="127.0.0.1,10.2.80.21,192.168.2.2"/>
    <add key="AllowedMigrationMaskedIPs" value="10.2.0.0;255.255.0.0,192.168.2.0;255.255.255.0"/>
    <add key="DeniedMigrationSingleIPs" value="10.2.80.21,192.168.2.2"/>
    <add key="DeniedMigrationMaskedIPs" value="10.2.0.0;255.255.0.0,192.168.2.0;255.255.255.0"/>

--- a/source/CommonJobs/CommonJobs.Raven.Mvc/Miscellaneous.Attributes.Controller/FilterIPAttribute.cs
+++ b/source/CommonJobs/CommonJobs.Raven.Mvc/Miscellaneous.Attributes.Controller/FilterIPAttribute.cs
@@ -95,25 +95,16 @@ namespace Miscellaneous.Attributes.Controller
 
             string userIpAddress = httpContext.Request.UserHostAddress;
 
-            try
-            {
-                // Check that the IP is allowed to access
-                bool ipAllowed = CheckAllowedIPs(userIpAddress);
+            // Check that the IP is allowed to access
+            bool ipAllowed = CheckAllowedIPs(userIpAddress);
 
-                // Check that the IP is not denied to access
-                bool ipDenied = CheckDeniedIPs(userIpAddress);    
+            // Check that the IP is not denied to access
+            bool ipDenied = CheckDeniedIPs(userIpAddress);    
 
-                // Only allowed if allowed and not denied
-                bool finallyAllowed = ipAllowed && !ipDenied;
+            // Only allowed if allowed and not denied
+            bool finallyAllowed = ipAllowed && !ipDenied;
 
-                return finallyAllowed;
-            }
-            catch (Exception e)
-            {
-                // Log the exception, probably something wrong with the configuration
-            }
-
-            return true; // if there was an exception, then we return true
+            return finallyAllowed;
         }
 
         /// <summary>

--- a/source/CommonJobs/CommonJobs.Raven.Mvc/Rainbow.Framework.Helpers/IPList.cs
+++ b/source/CommonJobs/CommonJobs.Raven.Mvc/Rainbow.Framework.Helpers/IPList.cs
@@ -42,13 +42,15 @@ namespace Rainbow.Framework.Helpers
         {
             uint res = 0;
             string[] elements = IPNumber.Split(new Char[] { '.' });
-            if (elements.Length == 4)
-            {
-                res = (uint)Convert.ToInt32(elements[0]) << 24;
-                res += (uint)Convert.ToInt32(elements[1]) << 16;
-                res += (uint)Convert.ToInt32(elements[2]) << 8;
-                res += (uint)Convert.ToInt32(elements[3]);
-            }
+
+            if (elements.Length != 4)
+                throw new ArgumentException(string.Format("'{0}' is not a valid IP v.4 address", IPNumber), "IPNumber");
+
+            res = (uint)Convert.ToInt32(elements[0]) << 24;
+            res += (uint)Convert.ToInt32(elements[1]) << 16;
+            res += (uint)Convert.ToInt32(elements[2]) << 8;
+            res += (uint)Convert.ToInt32(elements[3]);
+            
             return res;
         }
 


### PR DESCRIPTION
- Fix security issue parsing invalid IP v.4 addresses (now it throws an exception)
- Removing localhost from AllowedMigrationSingleIPs (web.config)
- Do not catch exceptions on FilterIPAttribute errors
- Add AntiForgeryToken to avoid IP spoofing
