### PR TITLE
Allow search by second name or surname

### DIFF
--- a/source/CommonJobs/CommonJobs.Infrastructure/ApplicantSearching/Applicant_QuickSearch.cs
+++ b/source/CommonJobs/CommonJobs.Infrastructure/ApplicantSearching/Applicant_QuickSearch.cs
@@ -112,8 +112,8 @@ namespace CommonJobs.Infrastructure.ApplicantSearching
                     OrphanAttachments = g.SelectMany(x => x.OrphanAttachments).Where(x => !g.SelectMany(y => y.AttachmentIds).Contains(x.Id)).ToArray()
                 };
 
-            Indexes.Add(x => x.FirstName, FieldIndexing.Analyzed);
-            Indexes.Add(x => x.LastName, FieldIndexing.Analyzed);
+            Indexes.Add(x => x.FullName1, FieldIndexing.Analyzed);
+            Indexes.Add(x => x.FullName2, FieldIndexing.Analyzed);
             Indexes.Add(x => x.Companies, FieldIndexing.Analyzed);
             Indexes.Add(x => x.Skills, FieldIndexing.Analyzed);
             Indexes.Add(x => x.AttachmentNames, FieldIndexing.Analyzed);

--- a/source/CommonJobs/CommonJobs.Infrastructure/EmployeeSearching/Employee_QuickSearch.cs
+++ b/source/CommonJobs/CommonJobs.Infrastructure/EmployeeSearching/Employee_QuickSearch.cs
@@ -142,8 +142,8 @@ namespace CommonJobs.Infrastructure.EmployeeSearching
                     OrphanAttachments = g.SelectMany(x => x.OrphanAttachments).Where(x => !g.SelectMany(y => y.AttachmentIds).Contains(x.Id)).ToArray()
                 };
             
-            Indexes.Add(x => x.FirstName, FieldIndexing.Analyzed);
-            Indexes.Add(x => x.LastName, FieldIndexing.Analyzed);
+            Indexes.Add(x => x.FullName1, FieldIndexing.Analyzed);
+            Indexes.Add(x => x.FullName2, FieldIndexing.Analyzed);
             Indexes.Add(x => x.Skills, FieldIndexing.Analyzed);
             Indexes.Add(x => x.AttachmentNames, FieldIndexing.Analyzed);
             Indexes.Add(x => x.AttachmentContent, FieldIndexing.Analyzed);


### PR DESCRIPTION
Al no estar buscando por FirstName y LastName y al no estar FullName1 y FullName2 indexados para full text search, estaba fallando al buscar en las segundas palabras de nombres y apellidos, peor todavía en los datos cargados actualmente donde pusieron todo en el apellido. 
