### PR TITLE
Fixed Firefox parsing of dates.

### DIFF
--- a/source/CommonJobs/CommonJobs.Mvc.UI/Content/EditEmployee/EditEmployee.js
+++ b/source/CommonJobs/CommonJobs.Mvc.UI/Content/EditEmployee/EditEmployee.js
@@ -51,7 +51,7 @@
                 })
                 .reduce(function (intermediateState, days) {
                     return intermediateState + days
-                }, 0)
+                }, 1)
                 .value();
             this.set('VacationsTotalDays', totalDays);
         },

--- a/source/CommonJobs/CommonJobs.Mvc.UI/Scripts/nervoustissue.js
+++ b/source/CommonJobs/CommonJobs.Mvc.UI/Scripts/nervoustissue.js
@@ -555,7 +555,10 @@
                 var month = noTimezoneDate.getMonth() + 1;
                 if (month < 10) month = "0" + month;
 
-                return (date.getFullYear() + "-" + month + "-" + date.getDate());
+                var day = date.getDate().toString();
+                if (day.length == 1) day = "0" + day;
+
+                return (date.getFullYear() + "-" + month + "-" + day);
             },
             bindUI: function () {
                 var me = this;


### PR DESCRIPTION
For Firefox the date parsing needs to be in yyyy-mm-dd instead of yyyy-mm-d
which Chrome also accepts. Still need to test this in IE.

The update of the dates now correctly sets the values so that the total for the
vacations are calculated on the fly.
