### PR TITLE
Fix sort order in Applicants and Employees

### DIFF
--- a/source/CommonJobs/CommonJobs.Infrastructure/ApplicantSearching/SearchApplicants.cs
+++ b/source/CommonJobs/CommonJobs.Infrastructure/ApplicantSearching/SearchApplicants.cs
@@ -53,7 +53,7 @@ namespace CommonJobs.Infrastructure.ApplicantSearching
             if (Parameters.Highlighted)
                 query = query.Where(x => x.IsHighlighted);
 
-            query = query.OrderBy(x => x.FullName1);
+            query = query.OrderBy(x => x.LastName).ThenBy(x => x.FirstName);
 
             if (Parameters.Skip > 0)
                 query = query.Skip(Parameters.Skip);

--- a/source/CommonJobs/CommonJobs.Infrastructure/EmployeeSearching/SearchEmployees.cs
+++ b/source/CommonJobs/CommonJobs.Infrastructure/EmployeeSearching/SearchEmployees.cs
@@ -49,7 +49,7 @@ namespace CommonJobs.Infrastructure.EmployeeSearching
             if (Parameters.SearchInAttachments)
                 predicate = predicate.Or(x => x.AttachmentContent.Any(y => y.StartsWith(Parameters.Term)));
 
-            query = query.Where(predicate).OrderBy(x => x.FullName1);
+            query = query.Where(predicate).OrderBy(x => x.LastName).ThenBy(x => x.FirstName);
 
             if (Parameters.Skip > 0)
                 query = query.Skip(Parameters.Skip);


### PR DESCRIPTION
Queries was sorting the documents based on an analyzed field, so
it was taking individual tokens in place of the complete value.

(More information: https://groups.google.com/group/ravendb/browse_thread/thread/6218add424663e14?pli=1)
