### PR TITLE
Fetch Seniority and CurrentPosition from Employee.

### DIFF
--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GenerateEvaluationsCommand.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GenerateEvaluationsCommand.cs
@@ -10,9 +10,9 @@ namespace CommonJobs.Application.Evaluations
 {
     public class GenerateEvaluationsCommand : Command
     {
-        private List<EmployeeEvaluation> _employeesEvaluations { get; set; }
+        private List<EmployeeEvaluationDTO> _employeesEvaluations { get; set; }
 
-        public GenerateEvaluationsCommand(List<EmployeeEvaluation> employeesEvaluations)
+        public GenerateEvaluationsCommand(List<EmployeeEvaluationDTO> employeesEvaluations)
         {
             _employeesEvaluations = employeesEvaluations;
         }
@@ -21,15 +21,23 @@ namespace CommonJobs.Application.Evaluations
         {
             foreach (var e in _employeesEvaluations)
             {
+                EmployeeEvaluation employeeEvaluation = new EmployeeEvaluation();
+
                 //Both Period and TemplateId will be fixed for this release
-                e.Period = "2015-06";
-                e.TemplateId = Template.DefaultTemplateId;
+                employeeEvaluation.Period = "2015-06";
+                employeeEvaluation.TemplateId = Template.DefaultTemplateId;
                 //---
+                employeeEvaluation.UserName = e.UserName;
+                employeeEvaluation.ResponsibleId = e.ResponsibleId;
+                employeeEvaluation.FullName = e.FullName;
+                //employeeEvaluation.Seniority will not be stored at this point
+                //employeeEvaluation.CurrentPosition will not be stored at this point
 
                 RavenSession.Store(e);
+
                 //After we create the evaluation, we create the calification document for the auto-evaluation and the responsible
-                ExecuteCommand(new GenerateCalificationCommand(e.Period, e.UserName, e.UserName, e.TemplateId, CalificationType.Auto, e.Id));
-                ExecuteCommand(new GenerateCalificationCommand(e.Period, e.UserName, e.ResponsibleId, e.TemplateId, CalificationType.Responsible, e.Id));
+                ExecuteCommand(new GenerateCalificationCommand(employeeEvaluation.Period, employeeEvaluation.UserName, employeeEvaluation.UserName, employeeEvaluation.TemplateId, CalificationType.Auto, employeeEvaluation.Id));
+                ExecuteCommand(new GenerateCalificationCommand(employeeEvaluation.Period, employeeEvaluation.UserName, employeeEvaluation.ResponsibleId, employeeEvaluation.TemplateId, CalificationType.Responsible, employeeEvaluation.Id));
             }
         }
     }

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEmployeesForEvaluationCommand.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEmployeesForEvaluationCommand.cs
@@ -1,20 +1,17 @@
 ﻿using CommonJobs.Application.Evaluations.EmployeeSearching;
 using CommonJobs.Utilities;
-using CommonJobs.Domain;
-using CommonJobs.Domain.Evaluations;
 using CommonJobs.Infrastructure.RavenDb;
 using Raven.Client.Linq;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using CommonJobs.Application.EvalForm;
 
 namespace CommonJobs.Application.Evaluations
 {
     /// <summary>
     /// Command for getting the list of employees to populate the evaluation generation screen
     /// </summary>
-    public class GetEmployeesForEvaluationCommand : Command<List<EmployeeEvaluation>>
+    public class GetEmployeesForEvaluationCommand : Command<List<EmployeeEvaluationDTO>>
     {
         private string _period;
 
@@ -23,7 +20,7 @@ namespace CommonJobs.Application.Evaluations
             _period = period;
         }
 
-        public override List<EmployeeEvaluation> ExecuteWithResult()
+        public override List<EmployeeEvaluationDTO> ExecuteWithResult()
         {
             RavenQueryStatistics stats;
             IQueryable<Employee_Search.Projection> query = RavenSession
@@ -38,7 +35,7 @@ namespace CommonJobs.Application.Evaluations
             var employeesToEval = employeesProjection.Select(e =>
             {
                 var period = e.EvaluationPeriods.EmptyIfNull().Where(x => x.Period == _period).FirstOrDefault();
-                return new EmployeeEvaluation()
+                return new EmployeeEvaluationDTO()
                 {
                     UserName = e.UserName,
                     Period = period == null ? null : period.Period,

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatorEmployeesCommand.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatorEmployeesCommand.cs
@@ -40,7 +40,7 @@ namespace CommonJobs.Application.EvalForm.Commands
                     UserName = e.UserName,
                     Period = e.Period,
                     CurrentPosition = e.CurrentPosition,
-                    Seniority = e.Seniority,
+                    Seniority = e.CurrentSeniority,
                     Evaluators = e.Evaluators != null ? e.Evaluators.ToList() : new List<string>(),
                     State = getEvaluationState(e),
                     Id = e.Id,

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatorEmployeesCommand.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatorEmployeesCommand.cs
@@ -35,6 +35,7 @@ namespace CommonJobs.Application.EvalForm.Commands
                 return new EmployeeEvaluationDTO()
                 {
                     IsResponsible = e.ResponsibleId == _responsibleId,
+                    ResponsibleId = e.ResponsibleId,
                     FullName = e.FullName,
                     UserName = e.UserName,
                     Period = e.Period,

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/DTOs/EmployeeEvaluationDTO.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/DTOs/EmployeeEvaluationDTO.cs
@@ -9,6 +9,8 @@ namespace CommonJobs.Application.EvalForm
     {
         public bool IsResponsible { get; set; }
 
+        public string ResponsibleId { get; set; }
+
         public string FullName { get; set; }
 
         public string CurrentPosition { get; set; }

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/EmployeeSearching/EmployeeToEvaluate_Search.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/EmployeeSearching/EmployeeToEvaluate_Search.cs
@@ -18,7 +18,7 @@ namespace CommonJobs.Application.EvalForm.EmployeeSearching
             public string UserName { get; set; }
             public string FullName { get; set; }
             public string CurrentPosition { get; set; }
-            public string Seniority { get; set; }
+            public string CurrentSeniority { get; set; }
             public string Period { get; set; }
             public string TemplateId { get; set; }
             public string[] Evaluators { get; set; }
@@ -104,7 +104,7 @@ namespace CommonJobs.Application.EvalForm.EmployeeSearching
                     UserName = g.Key,
                     FullName = g.Where(x => x.FullName != null).Select(x => x.FullName).FirstOrDefault(),
                     CurrentPosition = g.Where(x => x.CurrentPosition != null).Select(x => x.CurrentPosition).FirstOrDefault(),
-                    Seniority = g.Where(x => x.Seniority != null).Select(x => x.Seniority).FirstOrDefault(),
+                    Seniority = g.Where(x => x.CurrentSeniority != null).Select(x => x.CurrentSeniority).FirstOrDefault(),
                     Period = g.Where(x => x.Period != null).Select(x => x.Period).FirstOrDefault(),
                     TemplateId = g.Where(x => x.TemplateId != null).Select(x => x.TemplateId).FirstOrDefault(),
                     Evaluators = g.SelectMany(x => x.Evaluators).Where(x => x != null).ToArray(),

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/EmployeeSearching/EmployeeToEvaluate_Search.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/EmployeeSearching/EmployeeToEvaluate_Search.cs
@@ -1,4 +1,5 @@
-﻿using CommonJobs.Domain.Evaluations;
+﻿using CommonJobs.Domain;
+using CommonJobs.Domain.Evaluations;
 using Raven.Abstractions.Indexing;
 using Raven.Client.Indexes;
 using System;
@@ -31,6 +32,27 @@ namespace CommonJobs.Application.EvalForm.EmployeeSearching
 
         public EmployeeToEvaluate_Search()
         {
+            AddMap<Employee>(employees =>
+                from employee in employees
+                select new
+                {
+                    Id = (string)null,
+                    UserName = employee.UserName,
+                    FullName = (string)null,
+                    CurrentPosition = employee.CurrentPosition,
+                    Seniority = employee.Seniority,
+                    Period = (string)null,
+                    TemplateId = (string)null,
+                    Evaluators = new dynamic[0],
+                    ResponsibleId = (string)null,
+                    AutoEvaluationDone = false,
+                    ResponsibleEvaluationDone = false,
+                    CompanyEvaluationDone = false,
+                    OpenToDevolution = false,
+                    Finished = false
+
+                });
+
             AddMap<EmployeeEvaluation>(evaluations =>
                 from evaluation in evaluations
                 select new
@@ -38,8 +60,8 @@ namespace CommonJobs.Application.EvalForm.EmployeeSearching
                     Id = evaluation.Id,
                     UserName = evaluation.UserName,
                     FullName = evaluation.FullName,
-                    CurrentPosition = evaluation.CurrentPosition,
-                    Seniority = evaluation.Seniority,
+                    CurrentPosition = (string)null,
+                    Seniority = (string)null,
                     Period = evaluation.Period,
                     TemplateId = evaluation.TemplateId,
                     Evaluators = new dynamic[0],

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Models/PeriodCreation.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Models/PeriodCreation.cs
@@ -1,8 +1,6 @@
-﻿using CommonJobs.Domain.Evaluations;
-using System;
+﻿using CommonJobs.Application.EvalForm;
+using CommonJobs.Domain.Evaluations;
 using System.Collections.Generic;
-using System.Linq;
-using System.Web;
 
 namespace CommonJobs.Mvc.UI.Areas.Evaluations.Models
 {
@@ -10,9 +8,9 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations.Models
     {
         public PeriodCreation()
         {
-            Employees = new List<EmployeeEvaluation>();
+            Employees = new List<EmployeeEvaluationDTO>();
         }
-        public List<EmployeeEvaluation> Employees { get; set; }
+        public List<EmployeeEvaluationDTO> Employees { get; set; }
 
     }
 }


### PR DESCRIPTION
Modified the index to fetch both fields from Employee and removing them from being saved when creating the evaluation. Now those fields WILL BE saved in the evaluation once the company evaluation is finished (and the seniority has been changed or not).

Also modified the Evaluation creation part to use the same DTO as the Evaluator's employees list. 

Please review @andresmoschini @AlphaGit @joseguti84 @sofipacifico