### PR TITLE
Employee managers dashboard (backend)

### DIFF
--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatedEmployees.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatedEmployees.cs
@@ -10,11 +10,15 @@ namespace CommonJobs.Application.EvalForm.Commands
 {
     public class GetEvaluatedEmployees : Command<List<EmployeeEvaluationDTO>>
     {
-        private string _period;
+        /// <summary>
+        /// This will be an optional field. It represents the Period to filter the results.
+        /// If null will not be used.
+        /// </summary>
+        public string Period { get; set; }
 
-        public GetEvaluatedEmployees(string period)
+        public GetEvaluatedEmployees()
         {
-            _period = period;
+
         }
 
         public override List<EmployeeEvaluationDTO> ExecuteWithResult()
@@ -22,8 +26,12 @@ namespace CommonJobs.Application.EvalForm.Commands
             RavenQueryStatistics stats;
             IQueryable<EmployeeToEvaluate_Search.Projection> query = RavenSession
                 .Query<EmployeeToEvaluate_Search.Projection, EmployeeToEvaluate_Search>()
-                .Statistics(out stats)
-                .Where(e => e.Period == _period);
+                .Statistics(out stats);
+
+            if (Period != null)
+            {
+                query.Where(e => e.Period == Period);
+            }
 
             var employeesProjection = query.ToList();
 

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatedEmployees.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatedEmployees.cs
@@ -19,6 +19,12 @@ namespace CommonJobs.Application.EvalForm.Commands
 
         public override List<EmployeeEvaluationDTO> ExecuteWithResult()
         {
+            //3. If user is EmployeeManager
+
+            //var sessionRoles = (string[])HttpContext.Session[CommonJobs.Mvc.UI.Controllers.AccountController.SessionRolesKey] ?? new string[] { };
+            //var required = new List<string>() { "EmployeeManagers" };
+            //var isManager = sessionRoles.Intersect(required).Any();
+
             RavenQueryStatistics stats;
             IQueryable<EmployeeToEvaluate_Search.Projection> query = RavenSession
                 .Query<EmployeeToEvaluate_Search.Projection, EmployeeToEvaluate_Search>()

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatedEmployees.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluatedEmployees.cs
@@ -19,12 +19,6 @@ namespace CommonJobs.Application.EvalForm.Commands
 
         public override List<EmployeeEvaluationDTO> ExecuteWithResult()
         {
-            //3. If user is EmployeeManager
-
-            //var sessionRoles = (string[])HttpContext.Session[CommonJobs.Mvc.UI.Controllers.AccountController.SessionRolesKey] ?? new string[] { };
-            //var required = new List<string>() { "EmployeeManagers" };
-            //var isManager = sessionRoles.Intersect(required).Any();
-
             RavenQueryStatistics stats;
             IQueryable<EmployeeToEvaluate_Search.Projection> query = RavenSession
                 .Query<EmployeeToEvaluate_Search.Projection, EmployeeToEvaluate_Search>()

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluationCalificationsForEmployeeManager.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluationCalificationsForEmployeeManager.cs
@@ -39,11 +39,13 @@ namespace CommonJobs.Application.EvalForm.Commands
 
             Employee_Search.Projection employee = RavenSession
                 .Query<Employee_Search.Projection, Employee_Search>()
-                .Where(x => x.IsActive && x.UserName == evaluation.UserName).FirstOrDefault();
+                .Where(x => x.IsActive && x.UserName == evaluation.UserName)
+                .FirstOrDefault();
 
             var califications = RavenSession
                 .Query<EvaluationCalification>()
-                .Where(x => x.EvaluationId == evId).ToList();
+                .Where(x => x.EvaluationId == evId)
+                .ToList();
 
             var evaluators = califications.Where(c => c.Owner == CalificationType.Evaluator).Select(c => c.EvaluatorEmployee).ToList();
 

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluationCalificationsForEmployeeManager.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluationCalificationsForEmployeeManager.cs
@@ -1,0 +1,60 @@
+﻿using CommonJobs.Application.EvalForm.Dtos;
+using CommonJobs.Application.Evaluations.EmployeeSearching;
+using CommonJobs.Domain.Evaluations;
+using CommonJobs.Infrastructure.RavenDb;
+using System;
+using System.Linq;
+
+namespace CommonJobs.Application.EvalForm.Commands
+{
+    public class GetEvaluationCalificationsForEmployeeManager : Command<CalificationsDto>
+    {
+        private string _period;
+
+        private string _evaluatedUser;
+
+        public GetEvaluationCalificationsForEmployeeManager(string period, string evaluatedUser)
+        {
+            _period = period;
+
+            _evaluatedUser = evaluatedUser;
+        }
+
+        public override CalificationsDto ExecuteWithResult()
+        {
+            // The employeeManager should be able to see any evaluation that has been finished.
+
+            var evId = EmployeeEvaluation.GenerateEvaluationId(_period, _evaluatedUser);
+            var evaluation = RavenSession.Load<EmployeeEvaluation>(evId);
+
+            if (evaluation == null)
+            {
+                throw new ApplicationException(string.Format("Error: Evaluación inexistente: {0}.", evId));
+            }
+
+            if (!evaluation.Finished)
+            {
+                throw new ApplicationException(string.Format("Error: La evaluación: {0} debe estar finalizada para poder ser vista.", evId));
+            }
+
+            Employee_Search.Projection employee = RavenSession
+                .Query<Employee_Search.Projection, Employee_Search>()
+                .Where(x => x.IsActive && x.UserName == evaluation.UserName).FirstOrDefault();
+
+            var califications = RavenSession
+                .Query<EvaluationCalification>()
+                .Where(x => x.EvaluationId == evId).ToList();
+
+            var evaluators = califications.Where(c => c.Owner == CalificationType.Evaluator).Select(c => c.EvaluatorEmployee).ToList();
+
+            var evaluationDto = CalificationsEvaluationDto.Create(evaluation, evaluators, evaluation.CurrentPosition ?? employee.CurrentPosition, evaluation.Seniority ?? employee.Seniority);
+
+            return new CalificationsDto()
+            {
+                View = UserView.Company,
+                Evaluation = evaluationDto,
+                Califications = califications.Where(c => _evaluatedUser == c.EvaluatedEmployee && (c.Owner == CalificationType.Auto || c.Owner == CalificationType.Company)).ToList()
+            };
+        }
+    }
+}

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/CommonJobs.Application.Evaluations.csproj
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/CommonJobs.Application.Evaluations.csproj
@@ -67,6 +67,7 @@
   <ItemGroup>
     <Compile Include="Commands\GetEvaluatedEmployees.cs" />
     <Compile Include="Commands\GetEvaluationCalifications.cs" />
+    <Compile Include="Commands\GetEvaluationCalificationsForEmployeeManager.cs" />
     <Compile Include="Commands\StartDevolutionCommand.cs" />
     <Compile Include="Commands\UpdateCalificationsCommand.cs" />
     <Compile Include="Commands\UpdateEvaluatorsCommand.cs" />

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
@@ -54,7 +54,12 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations.Controllers
         public JsonNetResult GetDashboardEvaluationsForEmployeeManagers(string period)
         {
             PeriodEvaluation periodEvaluation = new PeriodEvaluation();
-            periodEvaluation.Evaluations = ExecuteCommand(new GetEvaluatedEmployees(period));
+            var command = new GetEvaluatedEmployees();
+            if (period != null)
+            {
+                command.Period = period;
+            }
+            periodEvaluation.Evaluations = ExecuteCommand(command);
             return Json(periodEvaluation);
         }
 

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsController.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsController.cs
@@ -52,6 +52,14 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations
         }
 
         [AcceptVerbs(HttpVerbs.Get)]
+        [CommonJobsAuthorize(Roles = "EmployeeManagers")]
+        public ActionResult ReportDashboard()
+        {
+            //TODO: Needs UI. Will call the API for the list (GetEvaluatedEmployees)
+            return View();
+        }
+
+        [AcceptVerbs(HttpVerbs.Get)]
         [Documentation("docs/manual-de-usuario/evaluaciones#Herramienta_para_Responsables_y_Calificadores")]
         public ActionResult PeriodEvaluation(string period)
         {

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsController.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsController.cs
@@ -110,7 +110,6 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations
             //2.d. Responsible with evaluation done, show company evaluation to complete
             //2.e. Responsible with company evaluation done, show every evaluation including auto
 
-            //var evId = EmployeeEvaluation.GenerateEvaluationId(period, username);
             var loggedUser = DetectUser();
 
             RavenQueryStatistics stats;

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/EvaluationsAreaRegistration.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/EvaluationsAreaRegistration.cs
@@ -20,11 +20,11 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations
                 new { controller = "EvaluationsApi", period = UrlParameter.Optional, username = UrlParameter.Optional }
             );
 
-            //context.MapRoute(
-            //    "Evaluations_report",
-            //    "Evaluations/report",
-            //    new { controller = "Evaluations", action = "ReportDashboard", period = UrlParameter.Optional }
-            //);
+            context.MapRoute(
+                "Evaluations_report",
+                "Evaluations/report",
+                new { controller = "Evaluations", action = "ReportDashboard" }
+            );
 
             context.MapRoute(
                 "Evaluations_creation",

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/EvaluationsAreaRegistration.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/EvaluationsAreaRegistration.cs
@@ -20,6 +20,12 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations
                 new { controller = "EvaluationsApi", period = UrlParameter.Optional, username = UrlParameter.Optional }
             );
 
+            //context.MapRoute(
+            //    "Evaluations_report",
+            //    "Evaluations/report",
+            //    new { controller = "Evaluations", action = "ReportDashboard", period = UrlParameter.Optional }
+            //);
+
             context.MapRoute(
                 "Evaluations_creation",
                 "Evaluations/create/{period}",


### PR DESCRIPTION
The idea is to have an EmployeeManagers dashboard for reviewing periods, employees, etc... For this stage, they will only be able to review the whole 2015-06 period and the evaluation's state. Future development will add the ability to select a period and/or an employee.

* Evaluations/report will be the new URL. Only EmployeeManagers will be able to access.
 * This view will call the **GetEvaluatedEmployees** command (with a fixed '2015-06' period)
 * If an evaluation is finished, the view should show a *'Ver evaluación'* link (please see the design mock: [HR Dashboard!](https://drive.google.com/drive/u/1/folders/0B4uqcOnEymWTfkx2MFVyelNaY1U3cW5fVUdZX0NxYS1Ta3RCeHFyckhCWkVYQVgtcEtPSzA)). This will call the **GetEvaluationCalificationsForEmployeeManager** command that will only return the auto & company califications if finished.

Both commands will probably mutate once this dashboard starts accepting filters.

Can you please review @andresmoschini @AlphaGit @sofipacifico?

Thanks!

