### PR TITLE
Improve logic for evaluators, employee and responsible

### DIFF
--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Views/Evaluations/Calification.cshtml
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Views/Evaluations/Calification.cshtml
@@ -115,7 +115,7 @@
         </tbody>
     </table>
     <div class="footer-evaluation" data-bind="if: isEvaluationEditable()">
-        <button class="button-evaluations primary-btn finish-btn" data-bind="click: onFinish">Finalizar</button>
+        <button class="button-evaluations primary-btn finish-btn" data-bind="click: onFinish">Finalizar Devolución</button>
         <p class="explanatory-text">Recuerda que una vez finalizada tu evaluación no podrás volver a editarla.</p>
     </div>
     <div id="loader-id" class="loader-container" data-bind="visible: isLoading()">

--- a/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/calification.js
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/calification.js
@@ -114,9 +114,12 @@
     }
 
     EvaluationViewModel.prototype.isValueEditable = function (calification) {
-        return !this.evaluation.finished && ((((this.userLogged == calification.calificationColumn.evaluatorEmployee) ||
-            (this.userView == 3 && calification.calificationColumn.evaluatorEmployee == "_company")) && !calification.calificationColumn.finished) ||
-            this.evaluation.readyForDevolution && this.userView == 3 && (calification.calificationColumn.owner == 3 || calification.calificationColumn.owner == 0))
+        return !this.evaluation.finished
+            && ((this.evaluation.readyForDevolution && this.userView == 3
+            && (calification.calificationColumn.owner == 3 || calification.calificationColumn.owner == 0))
+            || (((this.userLogged == calification.calificationColumn.evaluatorEmployee)
+            || (this.userView == 3 && calification.calificationColumn.evaluatorEmployee == "_company"))
+            && !calification.calificationColumn.finished))
     }
 
     EvaluationViewModel.prototype.fromJs = function (data) {

--- a/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/dashboard.js
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/dashboard.js
@@ -244,7 +244,7 @@
                     this.calificationActionClass("icon user");
                     this.calificationActionText("Evaluar");
                     return;
-                } else if (this.state() == 1 || this.state() == 3 ) {
+                } else if (this.state() == 1 || this.state() == 3) {
                     this.calificationActionText("Evaluar");
                     this.calificationActionClass("icon empresa");
                     this.calificationActionTooltip("Evaluar como empresa");

--- a/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/dashboard.js
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/dashboard.js
@@ -238,13 +238,13 @@
             });
         };
         this.state.subscribe(function () {
-            if (this.isResponsible && this.state() != 6) {
+            if (this.isResponsible && this.state() != 6 && this.isEditable) {
                 if (this.state() == 0 || this.state() == 2) {
                     this.calificationActionTooltip("Evaluar como responsable");
                     this.calificationActionClass("icon user");
                     this.calificationActionText("Evaluar");
                     return;
-                } else if (this.state() == 1 || this.state() == 3) {
+                } else if (this.state() == 1 || this.state() == 3 ) {
                     this.calificationActionText("Evaluar");
                     this.calificationActionClass("icon empresa");
                     this.calificationActionTooltip("Evaluar como empresa");
@@ -255,6 +255,11 @@
                     this.calificationActionTooltip("Hacer la devolución con el evaluado");
                     return;
                 }
+            } else if (!this.isResponsible && (this.state() == 4 || this.state() == 5)) {
+                this.calificationActionTooltip("Lista para devolucion");
+                this.calificationActionClass("icon view");
+                this.calificationActionText("Ver Evaluación");
+                return;
             } else if (!this.isResponsible && this.isEditable && this.state() != 6) {
                 this.calificationActionTooltip("Evaluar como evaluador");
                 this.calificationActionClass("icon user");


### PR DESCRIPTION
* DONE
* Responsible (works as always)
* Evaluators (can see comment when the evaluatio is finish, they don't can edit nothing after the evaluation is "Open for devolution")
* Employee (work as always)
* All status look fine
* When the evaluation is finished, just two columns are available, Company and Employee


* IMPROVE
* When the responsible does the devolution, for defect the row of "promedio, evaluadores y responsable" must be hidden (now for defect are shown all open)
* When the evalution is "Open for the devolution" the evalutors have to see "promedio, evalutores y responsable" calification. (now just see his evalution and the evalution of the employee)