### PR TITLE
Scheduled menu generation changes.

### DIFF
--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluationCalifications.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/GetEvaluationCalifications.cs
@@ -94,8 +94,9 @@ namespace CommonJobs.Application.EvalForm.Commands
             {
                 View = UserView.Evaluation,
                 Evaluation = evaluationDto,
-                Califications = califications.Where
-                (c => _loggedUser == c.EvaluatorEmployee || c.Owner == CalificationType.Auto || (evaluationDto.ReadyForDevolution && c.Owner == CalificationType.Company)).ToList()
+                Califications = califications.Where(c =>
+                    _loggedUser == c.EvaluatorEmployee || c.Owner == CalificationType.Auto || (evaluationDto.ReadyForDevolution && c.Owner == CalificationType.Company)
+                    ).ToList()
             };
         }
 

--- a/source/CommonJobs/CommonJobs.Application.MyMenu/ProcessMenuCommand.cs
+++ b/source/CommonJobs/CommonJobs.Application.MyMenu/ProcessMenuCommand.cs
@@ -15,15 +15,20 @@ namespace CommonJobs.Application.MyMenu
         private static Logger log = LogManager.GetCurrentClassLogger();
 
         public string MenuDefinitionId { get; set; }
-        
+
         public override void Execute()
         {
+            var now = Now();
+            var tomorrow = now.AddDays(1);
+
             var menuDefinition = ExecuteCommand(new GetMenuDefinitionCommand(MenuDefinitionId));
             var employeeMenus = ExecuteCommand(new GetEmployeeMenusCommand() { MenuDefinitionId = menuDefinition.Id });
-            var order = new MenuOrder(menuDefinition, Now(), employeeMenus);
+            var order = new MenuOrder(menuDefinition, tomorrow, employeeMenus);
             order.IsOrdered = true;
             RavenSession.Store(order);
-            menuDefinition.LastOrderDate = Now();
+
+            menuDefinition.LastOrderDate = now;
+            menuDefinition.LastGeneratedOrderDate = tomorrow;
         }
 
         protected override DateTime CalculateNextExecutionTime(DateTime start, DateTime scheduled)

--- a/source/CommonJobs/CommonJobs.Domain.MyMenu/Menu.cs
+++ b/source/CommonJobs/CommonJobs.Domain.MyMenu/Menu.cs
@@ -24,12 +24,12 @@ namespace CommonJobs.Domain.MyMenu
         public DateTime EndDate { get; set; }
         /// <summary>
         /// The date the last order has been generated
-        /// (If we are generating the 01/01/15 the order for the 02/01/15, this field will contain 01/01/15)
+        /// (If we are generating the order for 02/01/15 on 01/01/15, this field will contain 01/01/15)
         /// </summary>
         public DateTime LastOrderDate { get; set; }
         /// <summary>
         /// The date for the last generated order
-        /// (If we are generating the 01/01/15 the order for the 02/01/15, this field will contain 02/01/15)
+        /// (If we are generating the order for 02/01/15 on 01/01/15, this field will contain 02/01/15)
         /// </summary>
         public DateTime LastGeneratedOrderDate { get; set; }
         public string DeadlineTime { get; set; }

--- a/source/CommonJobs/CommonJobs.Domain.MyMenu/Menu.cs
+++ b/source/CommonJobs/CommonJobs.Domain.MyMenu/Menu.cs
@@ -22,7 +22,16 @@ namespace CommonJobs.Domain.MyMenu
         public StringKeyedCollection<Place> Places { get; set; }
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }
+        /// <summary>
+        /// The date the last order has been generated
+        /// (If we are generating the 01/01/15 the order for the 02/01/15, this field will contain 01/01/15)
+        /// </summary>
         public DateTime LastOrderDate { get; set; }
+        /// <summary>
+        /// The date for the last generated order
+        /// (If we are generating the 01/01/15 the order for the 02/01/15, this field will contain 02/01/15)
+        /// </summary>
+        public DateTime LastGeneratedOrderDate { get; set; }
         public string DeadlineTime { get; set; }
         public WeekDayOptionKeyedCollection<MenuItem> Foods { get; set; }
 
@@ -34,7 +43,9 @@ namespace CommonJobs.Domain.MyMenu
             //TODO: It will fail if the deadlineTime is near to 00:00
             var date = StartDate > now.Date ? StartDate : now.Date;
             if (LastOrderDate.Date >= date)
+            {
                 date = date.AddDays(1);
+            }
 
             var deadlineTS = TimeSpan.Zero;
             TimeSpan.TryParse(DeadlineTime, out deadlineTS);

--- a/source/CommonJobs/CommonJobs.Infrastructure.RavenDb/Schedule/SchedulableCommand.cs
+++ b/source/CommonJobs/CommonJobs.Infrastructure.RavenDb/Schedule/SchedulableCommand.cs
@@ -11,17 +11,19 @@ namespace CommonJobs.Infrastructure.RavenDb.Schedule
     {
         [JsonIgnore]
         public Func<DateTime> Now { get; set; }
-        
+
         public DateTime ExecuteAndGetNext(IDocumentSession ravenSession, Func<DateTime> now, DateTime scheduled)
         {
             RavenSession = ravenSession;
             Now = now;
             var start = Now();
             if (IsExecutionRequired())
+            {
                 Execute();
+            }
             return CalculateNextExecutionTime(start, scheduled);
         }
-        
+
         protected abstract DateTime CalculateNextExecutionTime(DateTime start, DateTime scheduled);
 
         /// <summary>


### PR DESCRIPTION
The menu scheduled task will now generate the menu for the following day. 
The idea is to generate every menu for the following day at 11:00AM. So, today 07/08/15 at 11AM, the scheduler will process the order for 08/08/15.

**Menu.LastOrderDate** is still being used to keep the date the last order (for the next day) was generated and will add a **Menu.LastGeneratedOrderDate** parameter that will contain the date of the last generated order.

Work needs to be done in order to use the correct date when navigating a user menu. So it will probably be updated into this PR. 

Can you please review @AlphaGit @andresmoschini @sofipacifico and let me know you thoughts? 

Thanks!
