### PR TITLE
Change a responsible of an evaluation

### DIFF
--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/ChangeResponsibleCommand.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/ChangeResponsibleCommand.cs
@@ -40,18 +40,26 @@ namespace CommonJobs.Application.EvalForm.Commands
                  .Query<Employee_Search.Projection, Employee_Search>()
                  .Where(x => x.IsActive && x.UserName == _newResponsibleName).FirstOrDefault();
 
+            
             if (newResponsible == null)
             {
                 throw new ApplicationException(string.Format("Error: Empleado inexistente: {0}.", _newResponsibleName));
             }
 
-            // If the new responsible is the same as the old one, cancel the operation.
-            if (evaluation.ResponsibleId == newResponsible.UserName)
+            // Check that new responsible is not the evaluated employee
+            if (evaluation.UserName == newResponsible.UserName )
+            {
+                throw new ApplicationException(string.Format("Error: {0} no puede ser responsable de su propia evaluación.", _newResponsibleName));
+            }
+
+                // If the new responsible is the same as the old one, cancel the operation.
+                if (evaluation.ResponsibleId == newResponsible.UserName)
             {
                 throw new ApplicationException(string.Format("Error: {0} es actualmente el responsable de esta evaluación.", newResponsible.UserName));
             }
 
-            // The only moment when a user cant change an evaluation responsible, is when the evaluation is complete and closed
+            // The only moment when a user cant change an evaluation responsible,
+            // is when the evaluation is complete and closed
             if (evaluation.Finished)
             {
                 throw new ApplicationException(string.Format("Error: Esta evaluación ya está cerrada. No se puede modificar el responsable."));

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/ChangeResponsibleCommand.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/ChangeResponsibleCommand.cs
@@ -1,0 +1,84 @@
+﻿using CommonJobs.Application.Evaluations.EmployeeSearching;
+using CommonJobs.Domain.Evaluations;
+using CommonJobs.Infrastructure.RavenDb;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CommonJobs.Application.EvalForm.Commands
+{
+    public class ChangeResponsibleCommand : Command
+    {
+
+        public string _evaluatedUser { get; set; }
+
+        public string _period { get; set; }
+
+        public string _newResponsible { get; set; }
+
+        public ChangeResponsibleCommand (string evaluatedUser, string period, string  newResponsible)
+        {
+            _evaluatedUser = evaluatedUser;
+            _period = period;
+            _newResponsible = newResponsible;
+        }
+
+        public override void Execute()
+        {
+            var evaluationId = EmployeeEvaluation.GenerateEvaluationId(_period, _evaluatedUser);
+            var evaluation = RavenSession.Load<EmployeeEvaluation>(evaluationId);
+
+            if (evaluation == null)
+            {
+                throw new ApplicationException(string.Format("Error: Evaluación inexistente: {0}.", evaluationId));
+            }
+
+            // Check that the new responsable exist
+            var responsible = RavenSession
+                 .Query<Employee_Search.Projection, Employee_Search>()
+                 .Where(x => x.IsActive && x.UserName == _newResponsible).FirstOrDefault();
+
+            if (responsible == null)
+            {
+                throw new ApplicationException(string.Format("Error: Empleado inexistente: {0}.", _newResponsible));
+            }
+
+            // The only moment when a user cant change an evaluation responsible, is when the evaluation is complete and closed
+            if (evaluation.Finished)
+            {
+                throw new ApplicationException(string.Format("Error: This evaluation is closed. Responsible can't be changed."));
+            }
+
+            // Load the responsable calification
+            var responsibleCalification = RavenSession.Advanced.LoadStartingWith<EvaluationCalification>(evaluationId + "/").Where(x=>x.Owner==CalificationType.Responsible).FirstOrDefault();
+
+            // If the old responsible has already made a calification,
+            // change it to an evaluator calification and create a new responsible one
+            if (responsibleCalification.Califications!=null)
+            {
+                responsibleCalification.Owner = CalificationType.Evaluator;
+                var newCalification = new EvaluationCalification
+                {
+                    Owner = CalificationType.Responsible,
+                    Period = evaluation.Period,
+                    EvaluationId = evaluation.Id,
+                    EvaluatedEmployee = evaluation.UserName,
+                    EvaluatorEmployee = responsible.UserName,
+                    TemplateId = "Template/Default"
+                };
+                RavenSession.Store(newCalification);
+            }
+            else
+            {
+                responsibleCalification.EvaluatorEmployee = responsible.UserName;
+            }
+
+            // Update responsable in the evaluation
+            evaluation.ResponsibleId = responsible.Id;
+
+            RavenSession.SaveChanges();
+        }
+    }
+}

--- a/source/CommonJobs/CommonJobs.Application.EvalForm/CommonJobs.Application.Evaluations.csproj
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/CommonJobs.Application.Evaluations.csproj
@@ -62,6 +62,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\ChangeResponsibleCommand.cs" />
     <Compile Include="Commands\DeleteEvaluationCommand.cs" />
     <Compile Include="Commands\GetEvaluatedEmployees.cs" />
     <Compile Include="Commands\GetEvaluationCalifications.cs" />

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
@@ -135,9 +135,9 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations.Controllers
 
         [AcceptVerbs(HttpVerbs.Post)]
         [CommonJobsAuthorize(Roles = "EvaluationManagers")]
-        public JsonNetResult ChangeResponsable (string evaluatedUser, string period, string newResponsible)
+        public JsonNetResult ChangeResponsable (string evaluatedUserName, string period, string newResponsibleName)
         {
-            ExecuteCommand(new ChangeResponsibleCommand(evaluatedUser, period, newResponsible));
+            ExecuteCommand(new ChangeResponsibleCommand(evaluatedUserName, period, newResponsibleName));
             return Json("OK");
         }
     }

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
@@ -132,5 +132,13 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations.Controllers
             ExecuteCommand(new DeleteEvaluationCommand(period));
             return Json("OK");
         }
+
+        [AcceptVerbs(HttpVerbs.Post)]
+        [CommonJobsAuthorize(Roles = "EvaluationManagers")]
+        public JsonNetResult ChangeResponsable (string evaluatedUser, string period, string newResponsible)
+        {
+            ExecuteCommand(new ChangeResponsibleCommand(evaluatedUser, period, newResponsible));
+            return Json("OK");
+        }
     }
 }


### PR DESCRIPTION
@andresmoschini 

Hi Andrés!
I added a new functionality to change the responsible of an evaluation.If the evaluation has started and the responsible has already evaluated, that evaluation will become an "Evaluator" type and a new "Responsible" evaluation will be created.
Could you review?