### PR TITLE
Fix Change responsible of an evaluation

### DIFF
--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/ChangeResponsibleCommand.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Commands/ChangeResponsibleCommand.cs
@@ -40,7 +40,7 @@ namespace CommonJobs.Application.EvalForm.Commands
                  .Query<Employee_Search.Projection, Employee_Search>()
                  .Where(x => x.IsActive && x.UserName == _newResponsibleName).FirstOrDefault();
 
-            
+
             if (newResponsible == null)
             {
                 throw new ApplicationException(string.Format("Error: Empleado inexistente: {0}.", _newResponsibleName));
@@ -98,7 +98,7 @@ namespace CommonJobs.Application.EvalForm.Commands
             }
 
             // Update responsible in the evaluation
-            evaluation.ResponsibleId = newResponsible.Id;
+            evaluation.ResponsibleId = newResponsible.UserName;
 
             RavenSession.SaveChanges();
         }

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
@@ -135,7 +135,7 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations.Controllers
 
         [AcceptVerbs(HttpVerbs.Post)]
         [CommonJobsAuthorize(Roles = "EvaluationManagers")]
-        public JsonNetResult ChangeResponsable (string evaluatedUserName, string period, string newResponsibleName)
+        public JsonNetResult ChangeResponsible (string evaluatedUserName, string period, string newResponsibleName)
         {
             ExecuteCommand(new ChangeResponsibleCommand(evaluatedUserName, period, newResponsibleName));
             return Json("OK");


### PR DESCRIPTION
@andresmoschini 

A minor fix to change the responsible of an evaluation using the UserName of the new responsible