### PR TITLE
fix logged user roles to see an evaluation

### DIFF
--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsApiController.cs
@@ -88,7 +88,9 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations.Controllers
         [AcceptVerbs(HttpVerbs.Get)]
         public JsonNetResult GetEvaluation(string username, string period)
         {
-            var sessionRoles = ExecuteCommand(new GetLoggedUserRoles(username));
+            var loggedUser = DetectUser();
+
+            var sessionRoles = ExecuteCommand(new GetLoggedUserRoles(loggedUser));
 
             var required = new List<string>() { "EmployeeManagers" };
             var isManager = sessionRoles.Intersect(required).Any();

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsController.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsController.cs
@@ -141,7 +141,7 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations
                 return HttpNotFound();
             }
 
-            var isManager = IsEmployeeManager(username);
+            var isManager = IsEmployeeManager(loggedUser);
             var isLoggedUserEvaluator = IsEvaluator(loggedUser, username, evaluation.ResponsibleId, evaluation.Evaluators);
             var isLoggedUserEvaluated = loggedUser == username;
 


### PR DESCRIPTION
@andresmoschini 

Hi Andres! this is a minor fix to solve the problem where an employee manager was not able to see a finished evaluation. Could you review?

Seems that it was looking for the evaluated employee stead of the one from the logged user