### PR TITLE
Fix state manager pop up

### DIFF
--- a/source/CommonJobs/CommonJobs.Application.EvalForm/Indexes/Period_Serch.cs
+++ b/source/CommonJobs/CommonJobs.Application.EvalForm/Indexes/Period_Serch.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace CommonJobs.Application.EvalForm.Indexes
 {
-    public class Period_Serch : AbstractMultiMapIndexCreationTask<Period_Serch.Projection>
+    public class Period_Search : AbstractMultiMapIndexCreationTask<Period_Search.Projection>
     {
         public class Projection
         {
@@ -16,7 +16,7 @@ namespace CommonJobs.Application.EvalForm.Indexes
             public string Period { get; set; }
         }
 
-        public Period_Serch()
+        public Period_Search()
         {
             AddMap<EvaluationCalification>(califications =>
                 from calification in califications

--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsController.cs
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Controllers/EvaluationsController.cs
@@ -201,19 +201,19 @@ namespace CommonJobs.Mvc.UI.Areas.Evaluations
             return responsibleId == loggedUser || (evaluators != null && evaluators.Contains(loggedUser));
         }
 
-        private List<Period_Serch.Projection> GetPeriods()
+        private List<Period_Search.Projection> GetPeriods()
         {
             return RavenSession
-                  .Query<Period_Serch.Projection, Period_Serch>()
+                  .Query<Period_Search.Projection, Period_Search>()
                   .Where(e => (e.UserName == DetectUser()))
                   .OrderByDescending(e => e.Period)
                   .ToList();
         }
 
-        private List<Period_Serch.Projection> GetReportPeriods()
+        private List<Period_Search.Projection> GetReportPeriods()
         {
             return RavenSession
-                .Query<Period_Serch.Projection, Period_Serch>()
+                .Query<Period_Search.Projection, Period_Search>()
                 .OrderByDescending(e => e.Period)
                 .ToList();
         }

--- a/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/dashboard.js
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/dashboard.js
@@ -138,7 +138,7 @@
 
     StateManagerModel.prototype.fromJs = function (data) {
         this.evaluation = data.evaluation;
-        this.posibleActions(data.evaluation.posibleRevertActions.$values);
+        this.posibleActions(data.evaluation.posibleRevertActions);
     }
 
     var Calificator = function (data) {
@@ -174,6 +174,7 @@
         var self = this;
         this.items = ko.observableArray();
         this.calificatorsManagerModel = new CalificatorsManager();
+        this.stateManagerModel = new StateManagerModel();
         if (data) {
             this.fromJS(data);
         }
@@ -316,7 +317,7 @@
         this.stateName = evaluationStates[this.state()];
         this.posibleRevertActions = data.PosibleRevertActions;
         this.hasPosibleActions = ko.computed(function () {
-            return data.PosibleRevertActions.$values.length > 0;
+            return data.PosibleRevertActions.length > 0;
         });
         this.stateClasses = "state-doc state-" + this.state();
         this.isCalificatorsEditable = ko.computed(function () {


### PR DESCRIPTION
Minor fix to show the Revert Action buttons in the PeriodEvaluation view.
I also added a renaming to `Period_Search` index which had a wrong name