### PR TITLE
Add autoexpandable binding to General Comments text area

### DIFF
--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Views/Evaluations/Calification.cshtml
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Views/Evaluations/Calification.cshtml
@@ -117,7 +117,7 @@
         </div>
         <div class="markdown-content" data-bind="markdownHtml: generalComment, visible: !isEditingGeneralComment()"></div>
         <div class="comments-container" data-bind="visible: isEditingGeneralComment()">
-          <textarea class="content-editable big-comment" data-bind="value: generalComment, enable: isEvaluationEditable()"></textarea>
+          <textarea class="content-editable big-comment" data-bind="autoExpandableValue: generalComment, valueUpdate: 'input', enable: isEvaluationEditable()"></textarea>
         </div>
         <button class="blue-button left" type="button" data-bind="click: endEdition, visible: isEditingGeneralComment()" style="">Listo</button>
       </div>


### PR DESCRIPTION
@andresmoschini 

Hi Andrés! 
A minor change to make general comments autoexpandable. I'll be merging it in a few minutes.