### PR TITLE
make the strengths, improve and actionPlan text areas auto-expandable

### DIFF
--- a/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Views/Evaluations/Calification.cshtml
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Areas/Evaluations/Views/Evaluations/Calification.cshtml
@@ -71,7 +71,7 @@
         </div>
         <div class="comments-container markdown-content" data-bind="markdownHtml:evaluation.strengthsComment, visible: !evaluation.isEditingStrengthsComment() && evaluation.strengthsComment()"></div>
         <div class="content-editable" data-bind="visible: evaluation.isEditingStrengthsComment">
-          <textarea data-bind="value: evaluation.strengthsComment"></textarea>
+          <textarea data-bind="autoExpandableValue: evaluation.strengthsComment, valueUpdate: 'input'"></textarea>
           <button class="blue-button left" type="button" data-bind="click: evaluation.endEdition.bind($data, evaluation.isEditingStrengthsComment)" style="">Listo</button>
         </div>
         <div class="title">
@@ -85,7 +85,7 @@
         </div>
         <div class="comments-container markdown-content" data-bind="markdownHtml: evaluation.improveComment, visible: !evaluation.isEditingImproveComment() && evaluation.improveComment()"></div>
         <div class="content-editable" data-bind="visible: evaluation.isEditingImproveComment">
-          <textarea data-bind="value: evaluation.improveComment"></textarea>
+          <textarea data-bind="autoExpandableValue: evaluation.improveComment, valueUpdate: 'input'"></textarea>
           <button class="blue-button left" type="button" data-bind="click: evaluation.endEdition.bind($data, evaluation.isEditingImproveComment)" style="">Listo</button>
         </div>
         <div class="title">
@@ -99,7 +99,7 @@
         </div>
         <div class="comments-container markdown-content" data-bind="markdownHtml:evaluation.actionPlanComment, visible: !evaluation.isEditingActionPlanComment() && evaluation.actionPlanComment()"></div>
         <div class="content-editable" data-bind="visible: evaluation.isEditingActionPlanComment">
-          <textarea data-bind="value: evaluation.actionPlanComment"></textarea>
+          <textarea data-bind="autoExpandableValue: evaluation.actionPlanComment, valueUpdate: 'input'"></textarea>
           <button class="blue-button left" type="button" data-bind="click: evaluation.endEdition.bind($data, evaluation.isEditingActionPlanComment)" style="">Listo</button>
         </div>
       </div>

--- a/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/auto-expandable-value.js
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/auto-expandable-value.js
@@ -10,7 +10,8 @@
         update: function (element, valueAccessor) {
             ko.bindingHandlers.value.update(element, valueAccessor);
             element.style.height = "1px";
-            element.style.height = 25 + element.scrollHeight + "px";
+            var scrollHeith = element.scrollHeight == 0 ? 28 : element.scrollHeight
+            element.style.height = 25 + scrollHeith + "px";
         }
     };
 })(this.ko)

--- a/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/auto-expandable-value.js
+++ b/source/CommonJobs/CommonJobs.MVC.UI/Scripts/Evaluations/auto-expandable-value.js
@@ -10,8 +10,8 @@
         update: function (element, valueAccessor) {
             ko.bindingHandlers.value.update(element, valueAccessor);
             element.style.height = "1px";
-            var scrollHeith = element.scrollHeight == 0 ? 28 : element.scrollHeight
-            element.style.height = 25 + scrollHeith + "px";
+            var scrollHeight = element.scrollHeight == 0 ? 28 : element.scrollHeight
+            element.style.height = 25 + scrollHeight + "px";
         }
     };
 })(this.ko)


### PR DESCRIPTION
@andresmoschini 

Minor change to fix a bug in the textarea of strengths, improves and action plan. No these areas are autoexpandables.

Merging in a moment